### PR TITLE
Removed debug line

### DIFF
--- a/protocolize-inventory/src/main/java/de/exceptionflug/protocolize/inventory/adapter/ClickWindowAdapter.java
+++ b/protocolize-inventory/src/main/java/de/exceptionflug/protocolize/inventory/adapter/ClickWindowAdapter.java
@@ -32,7 +32,8 @@ public class ClickWindowAdapter extends PacketAdapter<ClickWindow> {
         if(event.getPlayer() == null)
             return;
         final Inventory inventory = InventoryModule.getInventory(event.getPlayer().getUniqueId(), clickWindow.getWindowId());
-        if (inventory == null) return;
+        if (inventory == null)
+            return;
 
         short slot = clickWindow.getSlot();
         if (inventory.getType() == InventoryType.BREWING_STAND && ReflectionUtil.getProtocolVersion(event.getPlayer()) == MINECRAFT_1_8) {

--- a/protocolize-inventory/src/main/java/de/exceptionflug/protocolize/inventory/adapter/ClickWindowAdapter.java
+++ b/protocolize-inventory/src/main/java/de/exceptionflug/protocolize/inventory/adapter/ClickWindowAdapter.java
@@ -32,10 +32,7 @@ public class ClickWindowAdapter extends PacketAdapter<ClickWindow> {
         if(event.getPlayer() == null)
             return;
         final Inventory inventory = InventoryModule.getInventory(event.getPlayer().getUniqueId(), clickWindow.getWindowId());
-        if (inventory == null) {
-            ProxyServer.getInstance().getLogger().warning("[Protocolize] " + event.getPlayer().getName() + " has no open inventory with id " + clickWindow.getWindowId());
-            return;
-        }
+        if (inventory == null) return;
 
         short slot = clickWindow.getSlot();
         if (inventory.getType() == InventoryType.BREWING_STAND && ReflectionUtil.getProtocolVersion(event.getPlayer()) == MINECRAFT_1_8) {


### PR DESCRIPTION
Unnecessary debug line. There is no need (in production) to print out a message saying that a player doesn't have the window opened to console.