### PR TITLE
Fix error that happens with some antibots

### DIFF
--- a/protocolize-api/src/main/java/de/exceptionflug/protocolize/api/util/ReflectionUtil.java
+++ b/protocolize-api/src/main/java/de/exceptionflug/protocolize/api/util/ReflectionUtil.java
@@ -2,6 +2,7 @@ package de.exceptionflug.protocolize.api.util;
 
 import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
+import net.md_5.bungee.ServerConnector;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.Connection;
@@ -75,7 +76,7 @@ public final class ReflectionUtil {
       if (abstractPacketHandler instanceof PendingConnection) {
         return (Connection) abstractPacketHandler;
       }
-      if (serverConnectorClass.equals(abstractPacketHandler.getClass())) {
+      if (abstractPacketHandler instanceof ServerConnector) {
         final ProxiedPlayer player = (ProxiedPlayer) serverConnectorUserConnectionField.get(abstractPacketHandler);
         final Object upstreamBridge = getUpstreamBridge(player);
         if (upstreamBridge == null)
@@ -175,7 +176,7 @@ public final class ReflectionUtil {
 
 
   public static ServerInfo getServerInfo(final AbstractPacketHandler packetHandler) {
-    if (packetHandler.getClass().equals(serverConnectorClass)) {
+    if (packetHandler instanceof ServerConnector) {
       try {
         return (ServerInfo) serverConnectorTargetField.get(packetHandler);
       } catch (final IllegalAccessException e) {

--- a/protocolize-plugin/src/main/java/de/exceptionflug/protocolize/netty/ProtocolizeDecoderChannelHandler.java
+++ b/protocolize-plugin/src/main/java/de/exceptionflug/protocolize/netty/ProtocolizeDecoderChannelHandler.java
@@ -12,8 +12,10 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.unix.Errors.NativeIoException;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import net.md_5.bungee.ServerConnector;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.Connection;
+import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.protocol.*;
 import net.md_5.bungee.protocol.ProtocolConstants.Direction;
 
@@ -36,7 +38,7 @@ public class ProtocolizeDecoderChannelHandler extends MessageToMessageDecoder<Pa
     connection = ReflectionUtil.getConnection(abstractPacketHandler, ReflectionUtil.serverConnectorClass.isInstance(abstractPacketHandler));
     this.stream = stream;
     try {
-      if (abstractPacketHandler.getClass().getSimpleName().equals("ServerConnector")) {
+      if (abstractPacketHandler instanceof ServerConnector) {
         direction = Direction.TO_CLIENT;
         final Object ch = ReflectionUtil.serverConnectorChannelWrapperField.get(abstractPacketHandler);
         final Channel channel = (Channel) ReflectionUtil.channelWrapperChannelField.get(ch);
@@ -44,7 +46,7 @@ public class ProtocolizeDecoderChannelHandler extends MessageToMessageDecoder<Pa
         protocolVersion = (int) ReflectionUtil.protocolVersionField.get(minecraftDecoder);
         protocol = (Protocol) ReflectionUtil.protocolField.get(minecraftDecoder);
       } else {
-        if (abstractPacketHandler.getClass().getSimpleName().equals("InitialHandler")) {
+        if (abstractPacketHandler instanceof InitialHandler) {
           final Object ch = ReflectionUtil.initialHandlerChannelWrapperField.get(abstractPacketHandler);
           final Channel channel = (Channel) ReflectionUtil.channelWrapperChannelField.get(ch);
           final MinecraftDecoder minecraftDecoder = channel.pipeline().get(MinecraftDecoder.class);


### PR DESCRIPTION
This pull request fixes the incompatibility error that occurs with **some antibots**.

**Example of the message below:**
java.lang.IllegalArgumentException: Can not set final net.md_5.bungee.netty.ChannelWrapper field net.md_5.bungee.UserConnection.ch to com.nickuc.antibot.βσαςψΠφΠαφτ

**AntIBot used:** 
[https://www.nickuc.com/pt/details/nantibot](https://www.nickuc.com/pt/details/nantibot)

**Version that the error occurs:** 
I compiled the plugin with the latest changes made to the master branch