### PR TITLE
Fix protocol issues on Velocity

### DIFF
--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/providers/VelocityProtocolRegistrationProvider.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/providers/VelocityProtocolRegistrationProvider.java
@@ -9,6 +9,7 @@ import dev.simplix.protocolize.api.PacketDirection;
 import dev.simplix.protocolize.api.Protocol;
 import dev.simplix.protocolize.api.Protocolize;
 import dev.simplix.protocolize.api.mapping.ProtocolIdMapping;
+import dev.simplix.protocolize.api.mapping.ProtocolMapping;
 import dev.simplix.protocolize.api.packet.AbstractPacket;
 import dev.simplix.protocolize.api.packet.RegisteredPacket;
 import dev.simplix.protocolize.api.providers.MappingProvider;
@@ -25,8 +26,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -79,9 +80,14 @@ public final class VelocityProtocolRegistrationProvider implements ProtocolRegis
             StateRegistry.PacketRegistry registry = direction == PacketDirection.SERVERBOUND ? stateRegistry.serverbound : stateRegistry.clientbound;
             Class<? extends MinecraftPacket> velocityPacket = generateVelocityPacket(packetClass);
             List<StateRegistry.PacketMapping> velocityMappings = new ArrayList<>();
-            for (ProtocolIdMapping mapping : mappings) {
+
+            var sortedMappings = mappings.stream().sorted(Comparator.comparingInt(ProtocolMapping::protocolRangeEnd)).toArray(ProtocolIdMapping[]::new);
+
+            for (int i = 0; i < sortedMappings.length; i++) {
+                var mapping = sortedMappings[i];
                 mappingProvider.registerMapping(new RegisteredPacket(direction, packetClass), mapping);
-                velocityMappings.add(createVelocityMapping(mapping.protocolRangeStart(), 0, mapping.id(), false));
+                if (ProtocolVersion.MAXIMUM_VERSION.getProtocol() < mapping.protocolRangeStart() || ProtocolVersion.MAXIMUM_VERSION.getProtocol() < mapping.protocolRangeEnd()) continue;
+                velocityMappings.add(createVelocityMapping(mapping.protocolRangeStart(), mapping.protocolRangeEnd(), mapping.id(), i == sortedMappings.length - 1));
             }
             try {
                 doRegisterPacket(registry, velocityPacket, velocityMappings.toArray(new StateRegistry.PacketMapping[0]));


### PR DESCRIPTION
Fix a bug which allowed packets with higher protocol version than proxy to continue registering, and allowed packets to be provided with a higher protocol version than they support.

This bug seems to have only appeared on Velocity. While this is not the cleanest fix, I do consider it fine.

I've tested it, and it seems to work as expected.

Considering this is a time sensitive manner, it would be great to have it merged ASAP.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>