### PR TITLE
Correct artifact version in maven example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We provide some documentation on how to migrate your existing plugin to use the 
 <dependency>
     <groupId>dev.simplix</groupId>
     <artifactId>protocolize-api</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.1</version>
     <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
There's currently no artifact with version 2.2.2