### PR TITLE
fix: downstream packets in upstream listeners

### DIFF
--- a/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/providers/BungeeCordPacketListenerProvider.java
+++ b/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/providers/BungeeCordPacketListenerProvider.java
@@ -85,7 +85,8 @@ public final class BungeeCordPacketListenerProvider implements PacketListenerPro
             apiPacket = packet;
         }
         List<AbstractPacketListener<?>> listeners = listenersForType(clazz);
-        boolean sentToServer = ReflectionUtil.downstreamBridgeClass.isInstance(abstractPacketHandler);
+        boolean sentToServer = ReflectionUtil.downstreamBridgeClass.isInstance(abstractPacketHandler) ||
+            ReflectionUtil.serverConnectorClass.isInstance(abstractPacketHandler);
         Connection connection = ReflectionUtil.getConnection(abstractPacketHandler, sentToServer);
         if (connection == null) {
             return packet;


### PR DESCRIPTION
I have found out, that 1.8.9-1.18 chat packets from proxy to server were processed by serverconnector instead of downstream bridge, which caused UPSTREAM listeners to listen and edit these packets.