### PR TITLE
Some API additions

### DIFF
--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/AbstractPacketEvent.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/AbstractPacketEvent.java
@@ -1,0 +1,49 @@
+package dev.simplix.protocolize.api.listener;
+
+import dev.simplix.protocolize.api.player.ProtocolizePlayer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * This class is containing information about the packet event.
+ * <br><br>
+ * Date: 19.11.2023
+ *
+ * @author Rubenicos
+ */
+@Getter
+@Setter
+@Accessors(fluent = true)
+@AllArgsConstructor
+@ToString
+public abstract class AbstractPacketEvent<T> {
+
+    protected final ProtocolizePlayer player;
+    protected final Object server;
+    protected T packet;
+    protected boolean cancelled;
+
+    /**
+     * The protocolize player instance.
+     *
+     * @return The player instance or null if Protocolize was unable to track down the player
+     * during early communication phases like HANDSHAKE or STATUS.
+     */
+    public ProtocolizePlayer player() {
+        return player;
+    }
+
+    /**
+     * The platform dependent server info instance.
+     *
+     * @param <S> The type of the server info
+     * @return The platform dependent server info instance or null if Protocolize was unable to track down the server
+     * during early communication phases like HANDSHAKE or STATUS.
+     */
+    public <S> S server() {
+        return (S) server;
+    }
+}

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/AbstractPacketListener.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/AbstractPacketListener.java
@@ -2,7 +2,10 @@ package dev.simplix.protocolize.api.listener;
 
 import dev.simplix.protocolize.api.Direction;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.experimental.Accessors;
+
+import java.util.function.Consumer;
 
 /**
  * Used for listening to incoming and outgoing packets.
@@ -13,12 +16,18 @@ import lombok.experimental.Accessors;
  * @author Exceptionflug
  */
 @Getter
+@Setter
 @Accessors(fluent = true)
 public abstract class AbstractPacketListener<T> {
 
     private final Class<T> type;
     private final Direction direction;
     private final int priority;
+
+    private Consumer<PacketReceiveEvent<T>> onReceive;
+    private Consumer<PacketSendEvent<T>> onSend;
+
+    private transient boolean registered;
 
     /**
      * Creates an instance of your listener.
@@ -38,13 +47,33 @@ public abstract class AbstractPacketListener<T> {
      *
      * @param event The event containing information about the packet
      */
-    public abstract void packetReceive(PacketReceiveEvent<T> event);
+    public void packetReceive(PacketReceiveEvent<T> event) {
+        if (onReceive == null) {
+            packetEvent(event);
+        } else {
+            onReceive.accept(event);
+        }
+    }
 
     /**
      * Gets called when a packet has been processed by the Protocolize encoder handler.
      *
      * @param event The event containing information about the packet
      */
-    public abstract void packetSend(PacketSendEvent<T> event);
+    public void packetSend(PacketSendEvent<T> event) {
+        if (onSend == null) {
+            packetEvent(event);
+        } else {
+            onSend.accept(event);
+        }
+    }
 
+    /**
+     * Gets called when a packet has been processed by any Protocolize handler.
+     *
+     * @param event The event containing information about the packet
+     */
+    public void packetEvent(AbstractPacketEvent<T> event) {
+        // empty default method
+    }
 }

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/PacketReceiveEvent.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/PacketReceiveEvent.java
@@ -1,7 +1,6 @@
 package dev.simplix.protocolize.api.listener;
 
 import dev.simplix.protocolize.api.player.ProtocolizePlayer;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -17,35 +16,14 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(fluent = true)
-@AllArgsConstructor
 @ToString
-public class PacketReceiveEvent<T> {
+public class PacketReceiveEvent<T> extends AbstractPacketEvent<T> {
 
-    private final ProtocolizePlayer player;
-    private final Object server;
-    private T packet;
-    private boolean cancelled;
     private boolean dirty;
 
-    /**
-     * The platform {@link ProtocolizePlayer} instance.
-     *
-     * @return The player instance or null if Protocolize was unable to track down the player
-     * during early communication phases like HANDSHAKE or STATUS.
-     */
-    public ProtocolizePlayer player() {
-        return player;
-    }
-
-    /**
-     * The platform dependent server info instance.
-     *
-     * @param <S> The type of the server info
-     * @return The platform dependent server info instance or null if Protocolize was unable to track down the server
-     * during early communication phases like HANDSHAKE or STATUS.
-     */
-    public <S> S server() {
-        return (S) server;
+    public PacketReceiveEvent(ProtocolizePlayer player, Object server, T packet, boolean cancelled, boolean dirty) {
+        super(player, server, packet, cancelled);
+        this.dirty = dirty;
     }
 
     /**

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/PacketSendEvent.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/listener/PacketSendEvent.java
@@ -1,7 +1,6 @@
 package dev.simplix.protocolize.api.listener;
 
 import dev.simplix.protocolize.api.player.ProtocolizePlayer;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -17,34 +16,11 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(fluent = true)
-@AllArgsConstructor
 @ToString
-public class PacketSendEvent<T> {
+public class PacketSendEvent<T> extends AbstractPacketEvent<T> {
 
-    private final ProtocolizePlayer player;
-    private final Object server;
-    private T packet;
-    private boolean cancelled;
-
-    /**
-     * The protocolize player instance.
-     *
-     * @return The player instance or null if Protocolize was unable to track down the player
-     * during early communication phases like HANDSHAKE or STATUS.
-     */
-    public ProtocolizePlayer player() {
-        return player;
-    }
-
-    /**
-     * The platform dependent server info instance.
-     *
-     * @param <S> The type of the server info
-     * @return The platform dependent server info instance or null if Protocolize was unable to track down the server
-     * during early communication phases like HANDSHAKE or STATUS.
-     */
-    public <S> S server() {
-        return (S) server;
+    public PacketSendEvent(ProtocolizePlayer player, Object server, T packet, boolean cancelled) {
+        super(player, server, packet, cancelled);
     }
 
     /**

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/player/ProtocolizePlayer.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/player/ProtocolizePlayer.java
@@ -44,6 +44,10 @@ public interface ProtocolizePlayer {
 
     int protocolVersion();
 
+    Protocol decodeProtocol();
+
+    Protocol encodeProtocol();
+
     <T> T handle();
 
     Location location();

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/player/ProtocolizePlayer.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/player/ProtocolizePlayer.java
@@ -1,9 +1,7 @@
 package dev.simplix.protocolize.api.player;
 
 import com.google.common.collect.Lists;
-import dev.simplix.protocolize.api.Location;
-import dev.simplix.protocolize.api.PlayerInteract;
-import dev.simplix.protocolize.api.SoundCategory;
+import dev.simplix.protocolize.api.*;
 import dev.simplix.protocolize.api.inventory.Inventory;
 import dev.simplix.protocolize.api.inventory.PlayerInventory;
 import dev.simplix.protocolize.api.item.BaseItemStack;
@@ -28,9 +26,17 @@ public interface ProtocolizePlayer {
 
     PlayerInventory proxyInventory();
 
-    void sendPacket(Object packet);
+    default void sendPacket(Object packet) {
+        sendPacket(packet, Protocol.PLAY);
+    }
 
-    void sendPacketToServer(Object packet);
+    void sendPacket(Object packet, Protocol protocol);
+
+    default void sendPacketToServer(Object packet) {
+        sendPacketToServer(packet, Protocol.PLAY);
+    }
+
+    void sendPacketToServer(Object packet, Protocol protocol);
 
     Map<Integer, Inventory> registeredInventories();
 

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/providers/AbstractPacketListenerProvider.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/providers/AbstractPacketListenerProvider.java
@@ -1,0 +1,66 @@
+package dev.simplix.protocolize.api.providers;
+
+import com.google.common.base.Preconditions;
+import dev.simplix.protocolize.api.listener.AbstractPacketListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Date: 19.11.2023
+ *
+ * @author Rubenicos
+ */
+public abstract class AbstractPacketListenerProvider  implements PacketListenerProvider {
+
+    protected final List<AbstractPacketListener<?>> listeners = new ArrayList<>();
+
+    @Override
+    public <T, A extends AbstractPacketListener<T>> A registerListener(A listener) {
+        Preconditions.checkNotNull(listener, "The listener cannot be null!");
+        if (listeners.contains(listener)) {
+            throw new IllegalStateException("Listener already registered.");
+        }
+        addListener(listener);
+        return listener;
+    }
+
+    protected void addListener(AbstractPacketListener<?> listener) {
+        listeners.add(listener);
+        listener.registered(true);
+    }
+
+    @Override
+    public <T, A extends AbstractPacketListener<T>> A unregisterListener(A listener) throws IllegalArgumentException {
+        if (listeners.contains(listener)) {
+            listeners.remove(listener);
+            listener.registered(false);
+            return listener;
+        } else {
+            throw new IllegalArgumentException("Did not find " + listener.getClass().getName() + " as a registered listener");
+        }
+    }
+
+    @Override
+    public String debugInformation() {
+        StringBuilder builder = new StringBuilder("Generated export of " + getClass().getName() + ":\n\n");
+        for (AbstractPacketListener<?> listener : listeners) {
+            builder.append(" - ").append(listener.getClass().getName()).append(" listening for ")
+                .append(listener.type().getName()).append(" on ").append(listener.direction().name())
+                .append(" with priority ").append(listener.priority()).append("\n");
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public List<AbstractPacketListener<?>> listenersForType(Class<?> clazz) {
+        Preconditions.checkNotNull(clazz, "The clazz cannot be null!");
+        List<AbstractPacketListener<?>> out = new ArrayList<>();
+        for (AbstractPacketListener<?> listener : listeners) {
+            if (listener.type().equals(clazz)) {
+                out.add(listener);
+            }
+        }
+        return out;
+    }
+}

--- a/protocolize-api/src/main/java/dev/simplix/protocolize/api/providers/PacketListenerProvider.java
+++ b/protocolize-api/src/main/java/dev/simplix/protocolize/api/providers/PacketListenerProvider.java
@@ -1,5 +1,6 @@
 package dev.simplix.protocolize.api.providers;
 
+import dev.simplix.protocolize.api.Direction;
 import dev.simplix.protocolize.api.listener.AbstractPacketListener;
 
 import java.util.List;
@@ -11,9 +12,17 @@ import java.util.List;
  */
 public interface PacketListenerProvider {
 
-    void registerListener(AbstractPacketListener<?> listener);
+    default <T> AbstractPacketListener<T> registerListener(Class<T> packet, Direction direction) {
+        return registerListener(packet, direction, 0);
+    }
 
-    void unregisterListener(AbstractPacketListener<?> listener) throws IllegalArgumentException;
+    default <T> AbstractPacketListener<T> registerListener(Class<T> packet, Direction direction, int priority) {
+        return registerListener(new AbstractPacketListener<T>(packet, direction, priority) { });
+    }
+
+    <T, A extends AbstractPacketListener<T>> A registerListener(A listener);
+
+    <T, A extends AbstractPacketListener<T>> A unregisterListener(A listener) throws IllegalArgumentException;
 
     List<AbstractPacketListener<?>> listenersForType(Class<?> type);
 

--- a/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/netty/ProtocolizeDecoderChannelHandler.java
+++ b/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/netty/ProtocolizeDecoderChannelHandler.java
@@ -7,6 +7,7 @@ import dev.simplix.protocolize.api.providers.ProtocolRegistrationProvider;
 import dev.simplix.protocolize.bungee.ProtocolizePlugin;
 import dev.simplix.protocolize.bungee.providers.BungeeCordPacketListenerProvider;
 import dev.simplix.protocolize.bungee.util.CancelSendSignal;
+import dev.simplix.protocolize.bungee.util.ConversionUtils;
 import dev.simplix.protocolize.bungee.util.ReflectionUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -86,7 +87,7 @@ public final class ProtocolizeDecoderChannelHandler extends MessageToMessageDeco
                     try {
                         // Try packet rewrite
                         final ByteBuf buf = Unpooled.directBuffer();
-                        int packetID = REGISTRATION_PROVIDER.packetId(packet, protocolizeProtocol(),
+                        int packetID = REGISTRATION_PROVIDER.packetId(packet, ConversionUtils.protocolizeProtocol(protocol),
                             direction == Direction.TO_CLIENT ? PacketDirection.CLIENTBOUND : PacketDirection.SERVERBOUND,
                             protocolVersion);
                         if (packetID != -1) {
@@ -105,22 +106,6 @@ public final class ProtocolizeDecoderChannelHandler extends MessageToMessageDeco
                 out.add(msg);
             }
         }
-    }
-
-    private dev.simplix.protocolize.api.Protocol protocolizeProtocol() {
-        switch (protocol) {
-            case GAME:
-                return dev.simplix.protocolize.api.Protocol.PLAY;
-            case LOGIN:
-                return dev.simplix.protocolize.api.Protocol.LOGIN;
-            case STATUS:
-                return dev.simplix.protocolize.api.Protocol.STATUS;
-            case HANDSHAKE:
-                return dev.simplix.protocolize.api.Protocol.HANDSHAKE;
-            case CONFIGURATION:
-                return dev.simplix.protocolize.api.Protocol.CONFIGURATION;
-        }
-        return null;
     }
 
     @Override

--- a/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/player/BungeeCordProtocolizePlayer.java
+++ b/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/player/BungeeCordProtocolizePlayer.java
@@ -45,10 +45,10 @@ public class BungeeCordProtocolizePlayer implements ProtocolizePlayer {
     }
 
     @Override
-    public void sendPacket(Object packet) {
+    public void sendPacket(Object packet, Protocol protocol) {
         if (packet instanceof AbstractPacket) {
             BungeeCordProtocolizePacket pack = (BungeeCordProtocolizePacket) REGISTRATION_PROVIDER.createPacket((Class<? extends AbstractPacket>) packet.getClass(),
-                Protocol.PLAY, PacketDirection.CLIENTBOUND, protocolVersion());
+                protocol, PacketDirection.CLIENTBOUND, protocolVersion());
             pack.wrapper((AbstractPacket) packet);
             packet = pack;
         }
@@ -59,10 +59,10 @@ public class BungeeCordProtocolizePlayer implements ProtocolizePlayer {
     }
 
     @Override
-    public void sendPacketToServer(Object packet) {
+    public void sendPacketToServer(Object packet, Protocol protocol) {
         if (packet instanceof AbstractPacket) {
             BungeeCordProtocolizePacket pack = (BungeeCordProtocolizePacket) REGISTRATION_PROVIDER.createPacket((Class<? extends AbstractPacket>) packet.getClass(),
-                Protocol.PLAY, PacketDirection.SERVERBOUND, protocolVersion());
+                protocol, PacketDirection.SERVERBOUND, protocolVersion());
             pack.wrapper((AbstractPacket) packet);
             packet = pack;
         }

--- a/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/player/BungeeCordProtocolizePlayer.java
+++ b/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/player/BungeeCordProtocolizePlayer.java
@@ -7,6 +7,7 @@ import dev.simplix.protocolize.api.packet.AbstractPacket;
 import dev.simplix.protocolize.api.player.ProtocolizePlayer;
 import dev.simplix.protocolize.api.providers.ProtocolRegistrationProvider;
 import dev.simplix.protocolize.bungee.packet.BungeeCordProtocolizePacket;
+import dev.simplix.protocolize.bungee.util.ConversionUtils;
 import dev.simplix.protocolize.bungee.util.ReflectionUtil;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -89,6 +90,18 @@ public class BungeeCordProtocolizePlayer implements ProtocolizePlayer {
     @Override
     public int protocolVersion() {
         return ReflectionUtil.getProtocolVersion(player());
+    }
+
+    @Override
+    public Protocol decodeProtocol() {
+        net.md_5.bungee.protocol.Protocol protocol = ReflectionUtil.getDecodeProtocol(player());
+        return protocol == null ? null : ConversionUtils.protocolizeProtocol(protocol);
+    }
+
+    @Override
+    public Protocol encodeProtocol() {
+        net.md_5.bungee.protocol.Protocol protocol = ReflectionUtil.getEncodeProtocol(player());
+        return protocol == null ? null : ConversionUtils.protocolizeProtocol(protocol);
     }
 
     @Override

--- a/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/providers/BungeeCordPacketListenerProvider.java
+++ b/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/providers/BungeeCordPacketListenerProvider.java
@@ -7,7 +7,7 @@ import dev.simplix.protocolize.api.listener.AbstractPacketListener;
 import dev.simplix.protocolize.api.listener.PacketReceiveEvent;
 import dev.simplix.protocolize.api.listener.PacketSendEvent;
 import dev.simplix.protocolize.api.packet.AbstractPacket;
-import dev.simplix.protocolize.api.providers.PacketListenerProvider;
+import dev.simplix.protocolize.api.providers.AbstractPacketListenerProvider;
 import dev.simplix.protocolize.api.providers.ProtocolizePlayerProvider;
 import dev.simplix.protocolize.bungee.packet.BungeeCordProtocolizePacket;
 import dev.simplix.protocolize.bungee.util.ReflectionUtil;
@@ -28,41 +28,16 @@ import java.util.logging.Level;
  *
  * @author Exceptionflug
  */
-public final class BungeeCordPacketListenerProvider implements PacketListenerProvider {
+public final class BungeeCordPacketListenerProvider extends AbstractPacketListenerProvider {
 
     private static final ProtocolizePlayerProvider PLAYER_PROVIDER = Protocolize.playerProvider();
-    private final List<AbstractPacketListener<?>> listeners = new ArrayList<>();
 
     @Override
-    public void registerListener(AbstractPacketListener<?> listener) {
-        Preconditions.checkNotNull(listener, "The listener cannot be null!");
-        if (listeners.contains(listener)) {
-            throw new IllegalStateException("Listener already registered.");
-        }
+    protected void addListener(AbstractPacketListener<?> listener) {
         if (!AbstractPacket.class.isAssignableFrom(listener.type()) && !DefinedPacket.class.isAssignableFrom(listener.type())) {
             throw new IllegalStateException("The packet type is not a valid packet type. Allowed: AbstractPacket and DefinedPacket");
         }
-        listeners.add(listener);
-    }
-
-    @Override
-    public void unregisterListener(AbstractPacketListener<?> listener) throws IllegalArgumentException {
-        if (listeners.contains(listener)) {
-            listeners.remove(listener);
-        } else {
-            throw new IllegalArgumentException("Did not find " + listener.getClass().getName() + " as a registered listener");
-        }
-    }
-
-    @Override
-    public String debugInformation() {
-        StringBuilder builder = new StringBuilder("Generated export of " + getClass().getName() + ":\n\n");
-        for (AbstractPacketListener<?> listener : listeners) {
-            builder.append(" - ").append(listener.getClass().getName()).append(" listening for ")
-                .append(listener.type().getName()).append(" on ").append(listener.direction().name())
-                .append(" with priority ").append(listener.priority()).append("\n");
-        }
-        return builder.toString();
+        super.addListener(listener);
     }
 
     /**
@@ -214,18 +189,6 @@ public final class BungeeCordPacketListenerProvider implements PacketListenerPro
         if (connection instanceof ProxiedPlayer)
             return (ProxiedPlayer) connection;
         return null;
-    }
-
-    @Override
-    public List<AbstractPacketListener<?>> listenersForType(Class<?> clazz) {
-        Preconditions.checkNotNull(clazz, "The clazz cannot be null!");
-        List<AbstractPacketListener<?>> out = new ArrayList<>();
-        for (AbstractPacketListener<?> listener : listeners) {
-            if (listener.type().equals(clazz)) {
-                out.add(listener);
-            }
-        }
-        return out;
     }
 
 }

--- a/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/util/ConversionUtils.java
+++ b/protocolize-bungeecord/src/main/java/dev/simplix/protocolize/bungee/util/ConversionUtils.java
@@ -1,0 +1,47 @@
+package dev.simplix.protocolize.bungee.util;
+
+import dev.simplix.protocolize.api.Protocol;
+
+/**
+ * Date: 19.11.2023
+ *
+ * @author Rubenicos
+ */
+public final class ConversionUtils {
+
+    private ConversionUtils() {
+    }
+
+    public static net.md_5.bungee.protocol.Protocol bungeeCordProtocol(Protocol protocol) {
+        switch (protocol) {
+            case HANDSHAKE:
+                return net.md_5.bungee.protocol.Protocol.HANDSHAKE;
+            case STATUS:
+                return net.md_5.bungee.protocol.Protocol.STATUS;
+            case LOGIN:
+                return net.md_5.bungee.protocol.Protocol.LOGIN;
+            case PLAY:
+                return net.md_5.bungee.protocol.Protocol.GAME;
+            case CONFIGURATION:
+                return net.md_5.bungee.protocol.Protocol.CONFIGURATION;
+        }
+        return null;
+    }
+
+    public static Protocol protocolizeProtocol(net.md_5.bungee.protocol.Protocol protocol) {
+        switch (protocol) {
+            case GAME:
+                return dev.simplix.protocolize.api.Protocol.PLAY;
+            case LOGIN:
+                return dev.simplix.protocolize.api.Protocol.LOGIN;
+            case STATUS:
+                return dev.simplix.protocolize.api.Protocol.STATUS;
+            case HANDSHAKE:
+                return dev.simplix.protocolize.api.Protocol.HANDSHAKE;
+            case CONFIGURATION:
+                return dev.simplix.protocolize.api.Protocol.CONFIGURATION;
+        }
+        return null;
+    }
+
+}

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/player/InitialInboundConnectionProtocolizePlayer.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/player/InitialInboundConnectionProtocolizePlayer.java
@@ -2,6 +2,9 @@ package dev.simplix.protocolize.velocity.player;
 
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.client.InitialInboundConnection;
+import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
+import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
 import dev.simplix.protocolize.api.*;
 import dev.simplix.protocolize.api.inventory.Inventory;
 import dev.simplix.protocolize.api.inventory.PlayerInventory;
@@ -9,6 +12,7 @@ import dev.simplix.protocolize.api.packet.AbstractPacket;
 import dev.simplix.protocolize.api.player.ProtocolizePlayer;
 import dev.simplix.protocolize.api.providers.ProtocolRegistrationProvider;
 import dev.simplix.protocolize.velocity.packet.VelocityProtocolizePacket;
+import dev.simplix.protocolize.velocity.util.ConversionUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Field;
@@ -91,6 +95,32 @@ public class InitialInboundConnectionProtocolizePlayer implements ProtocolizePla
     @Override
     public int protocolVersion() {
         return connection.getProtocolVersion().getProtocol();
+    }
+
+    @Override
+    public Protocol decodeProtocol() {
+        try {
+            MinecraftDecoder minecraftDecoder = connection.getConnection().getChannel().pipeline().get(MinecraftDecoder.class);
+            if (minecraftDecoder != null) {
+                return ConversionUtils.protocolizeProtocol((StateRegistry) VelocityProtocolizePlayer.decoderStateField.get(minecraftDecoder));
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public Protocol encodeProtocol() {
+        try {
+            MinecraftEncoder minecraftEncoder = connection.getConnection().getChannel().pipeline().get(MinecraftEncoder.class);
+            if (minecraftEncoder != null) {
+                return ConversionUtils.protocolizeProtocol((StateRegistry) VelocityProtocolizePlayer.encoderStateField.get(minecraftEncoder));
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     @Override

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/player/InitialInboundConnectionProtocolizePlayer.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/player/InitialInboundConnectionProtocolizePlayer.java
@@ -50,9 +50,14 @@ public class InitialInboundConnectionProtocolizePlayer implements ProtocolizePla
 
     @Override
     public void sendPacket(Object packet) {
+        sendPacket(packet, Protocol.STATUS);
+    }
+
+    @Override
+    public void sendPacket(Object packet, Protocol protocol) {
         if (packet instanceof AbstractPacket) {
             VelocityProtocolizePacket pack = (VelocityProtocolizePacket) REGISTRATION_PROVIDER.createPacket((Class<? extends AbstractPacket>) packet.getClass(),
-                Protocol.STATUS, PacketDirection.CLIENTBOUND, protocolVersion());
+                protocol, PacketDirection.CLIENTBOUND, protocolVersion());
             if (pack == null) {
                 throw new IllegalStateException("Cannot send " + packet.getClass().getName() + " to players with protocol version " + protocolVersion());
             }
@@ -69,7 +74,7 @@ public class InitialInboundConnectionProtocolizePlayer implements ProtocolizePla
     }
 
     @Override
-    public void sendPacketToServer(Object packet) {
+    public void sendPacketToServer(Object packet, Protocol protocol) {
         throw new IllegalStateException("Not possible for initial inbound connections");
     }
 

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/player/VelocityProtocolizePlayer.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/player/VelocityProtocolizePlayer.java
@@ -46,10 +46,10 @@ public class VelocityProtocolizePlayer implements ProtocolizePlayer {
     }
 
     @Override
-    public void sendPacket(Object packet) {
+    public void sendPacket(Object packet, Protocol protocol) {
         if (packet instanceof AbstractPacket) {
             VelocityProtocolizePacket pack = (VelocityProtocolizePacket) REGISTRATION_PROVIDER.createPacket((Class<? extends AbstractPacket>) packet.getClass(),
-                Protocol.PLAY, PacketDirection.CLIENTBOUND, protocolVersion());
+                protocol, PacketDirection.CLIENTBOUND, protocolVersion());
             if (pack == null) {
                 throw new IllegalStateException("Cannot send " + packet.getClass().getName() + " to players with protocol version " + protocolVersion());
             }
@@ -63,10 +63,10 @@ public class VelocityProtocolizePlayer implements ProtocolizePlayer {
     }
 
     @Override
-    public void sendPacketToServer(Object packet) {
+    public void sendPacketToServer(Object packet, Protocol protocol) {
         if (packet instanceof AbstractPacket) {
             VelocityProtocolizePacket pack = (VelocityProtocolizePacket) REGISTRATION_PROVIDER.createPacket((Class<? extends AbstractPacket>) packet.getClass(),
-                Protocol.PLAY, PacketDirection.SERVERBOUND, protocolVersion());
+                protocol, PacketDirection.SERVERBOUND, protocolVersion());
             if (pack == null) {
                 throw new IllegalStateException("Cannot send " + packet.getClass().getName() + " to players with protocol version " + protocolVersion());
             }

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/providers/VelocityProtocolRegistrationProvider.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/providers/VelocityProtocolRegistrationProvider.java
@@ -15,6 +15,7 @@ import dev.simplix.protocolize.api.packet.RegisteredPacket;
 import dev.simplix.protocolize.api.providers.MappingProvider;
 import dev.simplix.protocolize.api.providers.ProtocolRegistrationProvider;
 import dev.simplix.protocolize.velocity.packet.VelocityProtocolizePacket;
+import dev.simplix.protocolize.velocity.util.ConversionUtils;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.ByteBuddy;
@@ -75,11 +76,11 @@ public final class VelocityProtocolRegistrationProvider implements ProtocolRegis
         Preconditions.checkNotNull(direction, "Direction cannot be null");
         Preconditions.checkNotNull(packetClass, "Packet class cannot be null");
         try {
-            ProtocolUtils.Direction velocityDirection = velocityDirection(direction);
+            ProtocolUtils.Direction velocityDirection = ConversionUtils.velocityDirection(direction);
             if (velocityDirection == null) {
                 return;
             }
-            StateRegistry stateRegistry = velocityProtocol(protocol);
+            StateRegistry stateRegistry = ConversionUtils.velocityProtocol(protocol);
             if (stateRegistry == null) {
                 return;
             }
@@ -150,11 +151,11 @@ public final class VelocityProtocolRegistrationProvider implements ProtocolRegis
                 log.debug("Unable to obtain id for " + direction.name() + " " + packetClass.getName() + " at protocol " + protocolVersion);
             }
         } else if (packet instanceof MinecraftPacket) {
-            ProtocolUtils.Direction velocityDirection = velocityDirection(direction);
+            ProtocolUtils.Direction velocityDirection = ConversionUtils.velocityDirection(direction);
             if (velocityDirection == null) {
                 return -1;
             }
-            StateRegistry stateRegistry = velocityProtocol(protocol);
+            StateRegistry stateRegistry = ConversionUtils.velocityProtocol(protocol);
             if (stateRegistry == null) {
                 return -1;
             }
@@ -167,12 +168,12 @@ public final class VelocityProtocolRegistrationProvider implements ProtocolRegis
 
     @Override
     public Object createPacket(Class<? extends AbstractPacket> clazz, Protocol protocol, PacketDirection direction, int protocolVersion) {
-        ProtocolUtils.Direction velocityDirection = velocityDirection(direction);
+        ProtocolUtils.Direction velocityDirection = ConversionUtils.velocityDirection(direction);
         if (velocityDirection == null) {
             log.debug("Unable to construct wrapper instance for " + clazz.getName() + ": Unknown packet direction to velocity: " + direction.name());
             return null;
         }
-        StateRegistry stateRegistry = velocityProtocol(protocol);
+        StateRegistry stateRegistry = ConversionUtils.velocityProtocol(protocol);
         if (stateRegistry == null) {
             log.debug("Unable to construct wrapper instance for " + clazz.getName() + ": Unknown protocol: " + protocol.name());
             return null;
@@ -221,32 +222,6 @@ public final class VelocityProtocolRegistrationProvider implements ProtocolRegis
             .make()
             .load(getClass().getClassLoader())
             .getLoaded();
-    }
-
-    private ProtocolUtils.Direction velocityDirection(PacketDirection direction) {
-        switch (direction) {
-            case CLIENTBOUND:
-                return ProtocolUtils.Direction.CLIENTBOUND;
-            case SERVERBOUND:
-                return ProtocolUtils.Direction.SERVERBOUND;
-        }
-        return null;
-    }
-
-    private StateRegistry velocityProtocol(Protocol protocol) {
-        switch (protocol) {
-            case LOGIN:
-                return StateRegistry.LOGIN;
-            case HANDSHAKE:
-                return StateRegistry.HANDSHAKE;
-            case STATUS:
-                return StateRegistry.STATUS;
-            case PLAY:
-                return StateRegistry.PLAY;
-            case CONFIGURATION:
-                return StateRegistry.CONFIG;
-        }
-        return null;
     }
 
     public static class ByteBuddyClassInjector {

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/util/ConversionUtils.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/util/ConversionUtils.java
@@ -15,12 +15,28 @@ public final class ConversionUtils {
     private ConversionUtils() {
     }
 
-    private static ProtocolUtils.Direction velocityDirection(PacketDirection direction) {
+    public static ProtocolUtils.Direction velocityDirection(PacketDirection direction) {
         switch (direction) {
             case SERVERBOUND:
                 return ProtocolUtils.Direction.SERVERBOUND;
             case CLIENTBOUND:
                 return ProtocolUtils.Direction.CLIENTBOUND;
+        }
+        return null;
+    }
+
+    public static StateRegistry velocityProtocol(Protocol protocol) {
+        switch (protocol) {
+            case LOGIN:
+                return StateRegistry.LOGIN;
+            case HANDSHAKE:
+                return StateRegistry.HANDSHAKE;
+            case STATUS:
+                return StateRegistry.STATUS;
+            case PLAY:
+                return StateRegistry.PLAY;
+            case CONFIGURATION:
+                return StateRegistry.CONFIG;
         }
         return null;
     }


### PR DESCRIPTION
## Packet listening
### Unified packet event class
Now `PacketReceiveEvent` and `PacketSendEvent` extends a common `AbstractPacketEvent` class with the new method `AbstractPacketListener#packetEvent()`, this is useful is you want to detect a packet that can be generated by the server and proxy.
### Functional listeners
Instead of making this:
```java
private MyPacketListener listener;

public void register() {
  listener = new MyPacketListener();
  Protocolize.listenerProvider().registerListener(listener);
}

public void unregister() {
  Protocolize.listenerProvider().unregisterListener(listener);
}

public class MyPacketListener extends AbstractPacketListener<Packet> {  
 
  public MyPacketListener() {  
    super(Packet.class, Direction.DOWNSTREAM, 0);  
  }  
 
  @Override  
  public void packetReceive(PacketReceiveEvent<Packet> event) {  
    // do something
    }  
  }  
}
```
Now you can make this:
```java
private AbstractPacketListener<Packet> listener;

public void register() {
  listener = Protocolize.listenerProvider().registerListener(Packet.class, Direction.DOWNSTREAM).onReceive(event -> {
    // do something
  });
}

public void unregister() {
  Protocolize.listenerProvider().unregisterListener(listener);
}
```

## Protocolize player
### Packet sending
Now ProtocolizePlayer instance can be used to send packets with different protocols, since `CONFIGURATION` protocol was added this is quite useful.
```java
ProtocolizePlayer player;
Object packet;
player.sendPacket(packet);
player.sendPacket(packet, Protocol.CONFIGURATION);
```
### Protocol information
Get current player protocol from `MinecraftDecoder` and `MinecraftEncoder`.
```java
ProtocolizePlayer player;
Protocol decoderProtocol = player.decoderProtocol();
Protocol encoderProtocol = player.encoderProtocol();
```