### PR TITLE
Add an NBT converter for components on Velocity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
         <build.number>unknown</build.number>
         <bungeecord.version>1.20-R0.2-SNAPSHOT</bungeecord.version>
-        <velocity.version>3.2.0-SNAPSHOT</velocity.version>
+        <velocity.version>3.3.0-SNAPSHOT</velocity.version>
         <bytebuddy.version>1.11.13</bytebuddy.version>
         <data.version>2.3.3</data.version>
     </properties>

--- a/protocolize-velocity/pom.xml
+++ b/protocolize-velocity/pom.xml
@@ -58,6 +58,11 @@
             <version>${bytebuddy.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-nbt</artifactId>
+            <version>4.16.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/providers/VelocityComponentConverterProvider.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/providers/VelocityComponentConverterProvider.java
@@ -1,7 +1,11 @@
 package dev.simplix.protocolize.velocity.providers;
 
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import dev.simplix.protocolize.api.ComponentConverter;
 import dev.simplix.protocolize.api.providers.ComponentConverterProvider;
+import dev.simplix.protocolize.velocity.util.AdventureNbtToQuerzNbtMapper;
+import net.kyori.adventure.nbt.BinaryTag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
@@ -44,7 +48,8 @@ public final class VelocityComponentConverterProvider implements ComponentConver
 
         @Override
         public Tag<?> toNbt(Component component) {
-            throw new UnsupportedOperationException("Adventure does not support nbt serialization yet");
+            BinaryTag adventureNbtTag = new ComponentHolder(ProtocolVersion.MINECRAFT_1_20_3, component).getBinaryTag();
+            return AdventureNbtToQuerzNbtMapper.adventureToQuerz(adventureNbtTag);
         }
 
         @Override
@@ -59,7 +64,8 @@ public final class VelocityComponentConverterProvider implements ComponentConver
 
         @Override
         public Component fromNbt(Tag<?> tag) {
-            throw new UnsupportedOperationException("Adventure does not support nbt deserialization yet");
+            BinaryTag adventureNbtTag = AdventureNbtToQuerzNbtMapper.querzToAdventure(tag);
+            return new ComponentHolder(ProtocolVersion.MINECRAFT_1_20_3, adventureNbtTag).getComponent();
         }
 
         @Override

--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/util/AdventureNbtToQuerzNbtMapper.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/util/AdventureNbtToQuerzNbtMapper.java
@@ -1,0 +1,180 @@
+package dev.simplix.protocolize.velocity.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import net.kyori.adventure.nbt.ArrayBinaryTag;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.BinaryTagType;
+import net.kyori.adventure.nbt.BinaryTagTypes;
+import net.kyori.adventure.nbt.ByteArrayBinaryTag;
+import net.kyori.adventure.nbt.ByteBinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.DoubleBinaryTag;
+import net.kyori.adventure.nbt.FloatBinaryTag;
+import net.kyori.adventure.nbt.IntArrayBinaryTag;
+import net.kyori.adventure.nbt.IntBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.LongArrayBinaryTag;
+import net.kyori.adventure.nbt.LongBinaryTag;
+import net.kyori.adventure.nbt.ShortBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
+import net.querz.nbt.tag.ByteArrayTag;
+import net.querz.nbt.tag.ByteTag;
+import net.querz.nbt.tag.CompoundTag;
+import net.querz.nbt.tag.DoubleTag;
+import net.querz.nbt.tag.FloatTag;
+import net.querz.nbt.tag.IntArrayTag;
+import net.querz.nbt.tag.IntTag;
+import net.querz.nbt.tag.ListTag;
+import net.querz.nbt.tag.LongArrayTag;
+import net.querz.nbt.tag.LongTag;
+import net.querz.nbt.tag.ShortTag;
+import net.querz.nbt.tag.StringTag;
+import net.querz.nbt.tag.Tag;
+
+public class AdventureNbtToQuerzNbtMapper {
+
+    private static BinaryTagType querzTagTypeToAdventure(Class<?> type) {
+        if (type == ByteArrayTag.class)
+            return BinaryTagTypes.BYTE_ARRAY;
+        else if (type == ByteTag.class)
+            return BinaryTagTypes.BYTE;
+        else if (type == CompoundTag.class)
+            return BinaryTagTypes.COMPOUND;
+        else if (type == DoubleTag.class)
+            return BinaryTagTypes.DOUBLE;
+        else if (type == FloatTag.class)
+            return BinaryTagTypes.FLOAT;
+        else if (type == IntArrayTag.class)
+            return BinaryTagTypes.INT_ARRAY;
+        else if (type == IntTag.class)
+            return BinaryTagTypes.INT;
+        else if (type == ListTag.class)
+            return BinaryTagTypes.LIST;
+        else if (type == LongArrayTag.class)
+            return BinaryTagTypes.LONG_ARRAY;
+        else if (type == LongTag.class)
+            return BinaryTagTypes.LONG;
+        else if (type == ShortTag.class)
+            return BinaryTagTypes.SHORT;
+        else if (type == StringTag.class)
+            return BinaryTagTypes.STRING;
+        else
+            return null;
+    }
+
+    private static Class<? extends Tag> adventureTagTypeToQuerz(BinaryTagType<? extends BinaryTag> type) {
+        if (type == BinaryTagTypes.BYTE_ARRAY) {
+            return ByteArrayTag.class;
+        } else if (type == BinaryTagTypes.BYTE) {
+            return ByteTag.class;
+        } else if (type == BinaryTagTypes.COMPOUND) {
+            return CompoundTag.class;
+        } else if (type == BinaryTagTypes.DOUBLE) {
+            return DoubleTag.class;
+        } else if (type == BinaryTagTypes.FLOAT) {
+            return FloatTag.class;
+        } else if (type == BinaryTagTypes.INT_ARRAY) {
+            return IntArrayTag.class;
+        } else if (type == BinaryTagTypes.INT) {
+            return IntTag.class;
+        } else if (type == BinaryTagTypes.LIST) {
+            return ListTag.class;
+        } else if (type == BinaryTagTypes.LONG_ARRAY) {
+            return LongArrayTag.class;
+        } else if (type == BinaryTagTypes.LONG) {
+            return LongTag.class;
+        } else if (type == BinaryTagTypes.SHORT) {
+            return ShortTag.class;
+        } else if (type == BinaryTagTypes.STRING) {
+            return StringTag.class;
+        }
+
+        return null;
+    }
+
+    public static BinaryTag querzToAdventure(Tag<?> tag) {
+        if (tag instanceof CompoundTag) {
+            CompoundTag compoundTag = (CompoundTag) tag;
+            Map<String, BinaryTag> entries = Map.of();
+            for (Map.Entry<String, Tag<?>> entry : compoundTag.entrySet()) {
+                entries.put(entry.getKey(), querzToAdventure(entry.getValue()));
+            }
+            return CompoundBinaryTag.from(entries);
+        } else if (tag instanceof ListTag) {
+            ListTag<Tag<?>> list = (ListTag<Tag<?>>) tag;
+            List<BinaryTag> items = new ArrayList<>(list.size());
+            list.iterator().forEachRemaining((item) -> items.add(querzToAdventure(item)));
+            return ListBinaryTag.listBinaryTag(querzTagTypeToAdventure(list.getTypeClass()), items);
+        } else if (tag instanceof ArrayBinaryTag) {
+            if (tag instanceof ByteArrayTag) {
+                return ByteArrayBinaryTag.byteArrayBinaryTag(((ByteArrayTag) tag).getValue());
+            } else if (tag instanceof IntArrayTag) {
+                return IntArrayBinaryTag.intArrayBinaryTag(((IntArrayTag) tag).getValue());
+            } else if (tag instanceof LongArrayTag) {
+                return LongArrayBinaryTag.longArrayBinaryTag(((LongArrayTag) tag).getValue());
+            }
+        } else if (tag instanceof ByteTag) {
+            return ByteBinaryTag.byteBinaryTag(((ByteTag) tag).asByte());
+        } else if (tag instanceof DoubleTag) {
+            return DoubleBinaryTag.doubleBinaryTag(((DoubleTag) tag).asDouble());
+        } else if (tag instanceof FloatTag) {
+            return FloatBinaryTag.floatBinaryTag(((FloatTag) tag).asFloat());
+        } else if (tag instanceof IntTag) {
+            return IntBinaryTag.intBinaryTag(((IntTag) tag).asInt());
+        } else if (tag instanceof LongTag) {
+            return LongBinaryTag.longBinaryTag(((LongTag) tag).asLong());
+        } else if (tag instanceof ShortTag) {
+            return ShortBinaryTag.shortBinaryTag(((ShortTag) tag).asShort());
+        } else if (tag instanceof StringTag) {
+            return StringBinaryTag.stringBinaryTag(((StringTag) tag).getValue());
+        }
+
+        throw new RuntimeException("Unexpected NBT tag type while converting: " + tag.getClass().getName());
+    }
+
+    public static Tag<?> adventureToQuerz(BinaryTag tag) {
+        if (tag instanceof CompoundBinaryTag) {
+            CompoundTag compound = new CompoundTag();
+            ((CompoundBinaryTag) tag).iterator().forEachRemaining((entry) -> {
+                compound.put(entry.getKey(), adventureToQuerz(entry.getValue()));
+            });
+            return compound;
+        } else if (tag instanceof ListBinaryTag) {
+            ListBinaryTag list = (ListBinaryTag) tag;
+            ListTag listTag = new ListTag(adventureTagTypeToQuerz(list.elementType()));
+
+            List<Tag<?>> items = new ArrayList<>(list.size());
+            list.iterator().forEachRemaining((item) -> items.add(adventureToQuerz(item)));
+
+            listTag.addAll(items);
+            return listTag;
+        } else if (tag instanceof ArrayBinaryTag) {
+            if (tag instanceof ByteArrayBinaryTag) {
+                return new ByteArrayTag(((ByteArrayBinaryTag) tag).value());
+            } else if (tag instanceof IntArrayBinaryTag) {
+                return new IntArrayTag(((IntArrayBinaryTag) tag).value());
+            } else if (tag instanceof LongArrayBinaryTag) {
+                return new LongArrayTag(((LongArrayBinaryTag) tag).value());
+            }
+        } else if (tag instanceof ByteBinaryTag) {
+            return new ByteTag(((ByteBinaryTag) tag).value());
+        } else if (tag instanceof DoubleBinaryTag) {
+            return new DoubleTag(((DoubleBinaryTag) tag).value());
+        } else if (tag instanceof FloatBinaryTag) {
+            return new FloatTag(((FloatBinaryTag) tag).value());
+        } else if (tag instanceof IntBinaryTag) {
+            return new IntTag(((IntBinaryTag) tag).value());
+        } else if (tag instanceof LongBinaryTag) {
+            return new LongTag(((LongBinaryTag) tag).value());
+        } else if (tag instanceof ShortBinaryTag) {
+            return new ShortTag(((ShortBinaryTag) tag).value());
+        } else if (tag instanceof StringBinaryTag) {
+            return new StringTag(((StringBinaryTag) tag).value());
+        }
+
+        throw new RuntimeException("Unexpected NBT tag type while converting: " + tag.getClass().getName());
+    }
+}


### PR DESCRIPTION
This is a workaround to allow Prototolize to send NBT components until KyoriPowered/adventure#995 is resolved.

Using Velocity's [`ComponentHolder`](https://github.com/PaperMC/Velocity/blob/8891faa52c85c165ce37540adc236f4678617b69/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java#L105), I convert the component to an Adventure NBT tag (see [`adventure-nbt`](https://jd.advntr.dev/nbt/4.16.0/net/kyori/adventure/nbt/package-summary.html)), then convert the Adventure NBT tag to a Querz NBT tag using a custom mapper class.

Basic testing with item names, lores, and inventory titles (using Protocolize's [OpenWindow](https://github.com/Exceptionflug/protocolize-data/blob/master/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/packets/OpenWindow.java) and [WindowItems](https://github.com/Exceptionflug/protocolize-data/blob/master/protocolize-data-bundle/src/main/java/dev/simplix/protocolize/data/packets/WindowItems.java) packets) works fine on 1.20.4.

I have not tested on lower versions or old versions of Velocity that don't support 1.20.3 and therefore don't have a ComponentHolder class. Let me know if there is a better way to get the protocol version than hard-coding `ProtocolVersion.MINECRAFT_1_20_3`.