### PR TITLE
Fix UnsupportedOperationException on AbstractImmutableMap

### DIFF
--- a/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/util/AdventureNbtToQuerzNbtMapper.java
+++ b/protocolize-velocity/src/main/java/dev/simplix/protocolize/velocity/util/AdventureNbtToQuerzNbtMapper.java
@@ -1,6 +1,7 @@
 package dev.simplix.protocolize.velocity.util;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -98,7 +99,7 @@ public class AdventureNbtToQuerzNbtMapper {
     public static BinaryTag querzToAdventure(Tag<?> tag) {
         if (tag instanceof CompoundTag) {
             CompoundTag compoundTag = (CompoundTag) tag;
-            Map<String, BinaryTag> entries = Map.of();
+            Map<String, BinaryTag> entries = new HashMap<>(compoundTag.size());
             for (Map.Entry<String, Tag<?>> entry : compoundTag.entrySet()) {
                 entries.put(entry.getKey(), querzToAdventure(entry.getValue()));
             }


### PR DESCRIPTION
`Map.of()` creates an `AbstractImmutableMap` which throws `UnsupportedOperationException` on `put()`. The PR changes it to use `new HashMap<>()` with the count of the `CompoundTag` entries